### PR TITLE
Sidebar Navigation: Support button should open the user’s mail app

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -42,6 +42,16 @@ describe("Sidebar Navigation", () => {
       // check that text is not rendered
       cy.get("nav").contains("Issues").should("not.exist");
     });
+
+    it("Support link has correct href value", () => {
+      cy.get("nav")
+        .contains("Support")
+        .should(
+          "have.attr",
+          "href",
+          "mailto:support@prolog-app.com?subject=Support Request: "
+        );
+    });
   });
 
   context("mobile resolution", () => {

--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -1,3 +1,5 @@
+const firstUlTagSelectorInNav = "nav > ul:nth-of-type(1)";
+
 describe("Sidebar Navigation", () => {
   beforeEach(() => {
     cy.visit("http://localhost:3000/dashboard");
@@ -36,7 +38,11 @@ describe("Sidebar Navigation", () => {
       cy.get("nav").contains("Collapse").click();
 
       // check that links still exist and are functionable
-      cy.get("nav").find("a").should("have.length", 5).eq(1).click();
+      cy.get(firstUlTagSelectorInNav)
+        .find("a")
+        .should("have.length", 5)
+        .eq(1)
+        .click();
       cy.url().should("eq", "http://localhost:3000/dashboard/issues");
 
       // check that text is not rendered
@@ -90,7 +96,7 @@ describe("Sidebar Navigation", () => {
       isInViewport("nav");
 
       // check that all links are rendered
-      cy.get("nav").find("a").should("have.length", 5);
+      cy.get(firstUlTagSelectorInNav).find("a").should("have.length", 5);
 
       // Support button should be rendered but Collapse button not
       cy.get("nav").contains("Support").should("exist");

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { useContext, useState } from "react";
 import styled, { css } from "styled-components";
@@ -198,11 +199,12 @@ export function SidebarNavigation() {
           </LinkList>
 
           <List>
-            <MenuItemButton
+            <MenuItemLink
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              href="mailto:support@prolog-app.com?subject=Support Request: "
+              isActive={false}
             />
             <CollapseMenuItem
               text="Collapse"


### PR DESCRIPTION
- The recipient should be “support@prolog-app.com”
- The subject line should be pre-filled with “Support Request: “
- Covered by a Cypress test

## Task board
https://profy.dev/project/react-job-simulator/board

## Design
n/a

## Video

https://user-images.githubusercontent.com/20284226/210713112-91f72136-df25-499f-a123-d8f3372aed84.mov


